### PR TITLE
Remove extra bracket

### DIFF
--- a/SMRTMONSup/SMRTMON.db
+++ b/SMRTMONSup/SMRTMON.db
@@ -80,7 +80,7 @@ record(ai, "$(P)STATUS")
 {
 	field(INP, "$(P)STATBUFFER.K CP MS")
 	field(EGU, "")
-	field(DESC, "Magnet status value"))
+	field(DESC, "Magnet status value")
     field(DTYP, "Soft Channel")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:STATUS")


### PR DESCRIPTION
System test IOCS was failing to get the MAGNETSTATUS PV because there was a syntax error in the db file and it wasn't loaded correctly. Remove the syntax error here.